### PR TITLE
OSC: add support for double and long int types

### DIFF
--- a/modules/juce_osc/osc/juce_OSCArgument.cpp
+++ b/modules/juce_osc/osc/juce_OSCArgument.cpp
@@ -27,7 +27,9 @@ namespace juce
 {
 
 OSCArgument::OSCArgument (int32 v)              : type (OSCTypes::int32),   intValue (v) {}
+OSCArgument::OSCArgument (int64 v)				: type (OSCTypes::int64),	longValue(v) {}
 OSCArgument::OSCArgument (float v)              : type (OSCTypes::float32), floatValue (v) {}
+OSCArgument::OSCArgument (double v)				: type (OSCTypes::float64), doubleValue(v) {}
 OSCArgument::OSCArgument (const String& s)      : type (OSCTypes::string),  stringValue (s) {}
 OSCArgument::OSCArgument (MemoryBlock b)        : type (OSCTypes::blob),    blob (std::move (b)) {}
 OSCArgument::OSCArgument (OSCColour c)          : type (OSCTypes::colour),  intValue ((int32) c.toInt32()) {}
@@ -45,10 +47,19 @@ String OSCArgument::getString() const noexcept
 int32 OSCArgument::getInt32() const noexcept
 {
     if (isInt32())
-        return intValue;
+        return longValue;
 
     jassertfalse; // you must check the type of an argument before attempting to get its value!
     return 0;
+}
+
+int64 OSCArgument::getInt64() const noexcept
+{
+	if (isInt64())
+		return intValue;
+
+	jassertfalse; // you must check the type of an argument before attempting to get its value!
+	return 0;
 }
 
 float OSCArgument::getFloat32() const noexcept
@@ -58,6 +69,15 @@ float OSCArgument::getFloat32() const noexcept
 
     jassertfalse; // you must check the type of an argument before attempting to get its value!
     return 0.0f;
+}
+
+double OSCArgument::getFloat64() const noexcept
+{
+	if (isFloat64())
+		return doubleValue;
+
+	jassertfalse; // you must check the type of an argument before attempting to get its value!
+	return 0.0f;
 }
 
 const MemoryBlock& OSCArgument::getBlob() const noexcept
@@ -138,7 +158,7 @@ public:
             expect (! arg.isBlob());
             expect (! arg.isColour());
 
-            expectEquals (arg.getFloat32(), value);
+            expect (arg.getFloat32() == value);
         }
 
         beginTest ("String");

--- a/modules/juce_osc/osc/juce_OSCArgument.h
+++ b/modules/juce_osc/osc/juce_OSCArgument.h
@@ -43,8 +43,14 @@ public:
     /** Constructs an OSCArgument with type int32 and a given value. */
     OSCArgument (int32 value);
 
+	/** Constructs an OSCArgument with type int64 and a given value. */
+	OSCArgument(int64 value);
+
     /** Constructs an OSCArgument with type float32 and a given value. */
     OSCArgument (float value);
+
+	/** Constructs an OSCArgument with type float32 and a given value. */
+	OSCArgument(double value);
 
     /** Constructs an OSCArgument with type string and a given value */
     OSCArgument (const String& value);
@@ -68,8 +74,14 @@ public:
     /** Returns whether the type of the OSCArgument is int32. */
     bool isInt32() const noexcept           { return type == OSCTypes::int32; }
 
+	/** Returns whether the type of the OSCArgument is int32. */
+	bool isInt64() const noexcept			{ return type == OSCTypes::int64; }
+
     /** Returns whether the type of the OSCArgument is float. */
     bool isFloat32() const noexcept         { return type == OSCTypes::float32; }
+
+	/** Returns whether the type of the OSCArgument is double. */
+	bool isFloat64() const noexcept			{ return type == OSCTypes::float64; }
 
     /** Returns whether the type of the OSCArgument is string. */
     bool isString() const noexcept          { return type == OSCTypes::string; }
@@ -85,10 +97,20 @@ public:
     */
     int32 getInt32() const noexcept;
 
+	/** Returns the value of the OSCArgument as an int32.
+		If the type of the OSCArgument is not int32, the behaviour is undefined.
+	*/
+	int64 getInt64() const noexcept;
+
     /** Returns the value of the OSCArgument as a float32.
         If the type of the OSCArgument is not float32, the behaviour is undefined.
     */
     float getFloat32() const noexcept;
+
+	/** Returns the value of the OSCArgument as a float64.
+		If the type of the OSCArgument is not float64, the behaviour is undefined.
+	*/
+	double getFloat64() const noexcept;
 
     /** Returns the value of the OSCArgument as a string.
         If the type of the OSCArgument is not string, the behaviour is undefined.
@@ -116,6 +138,12 @@ private:
         int32 intValue;
         float floatValue;
     };
+
+	union
+	{
+		int64 longValue;
+		double doubleValue;
+	};
 
     String stringValue;
     MemoryBlock blob;

--- a/modules/juce_osc/osc/juce_OSCBundle.cpp
+++ b/modules/juce_osc/osc/juce_OSCBundle.cpp
@@ -210,7 +210,7 @@ private:
         expect (e[0].getMessage().size() == 1);
         expect (e[0].getMessage().begin()->getInt32() == testInt);
         expect (e[1].getMessage().size() == 2);
-        expectEquals (e[1].getMessage()[1].getFloat32(), testFloat);
+        expect (e[1].getMessage()[1].getFloat32() == testFloat);
     }
 };
 
@@ -237,7 +237,7 @@ public:
             expect (element.isMessage());
             expect (element.getMessage().size() == 1);
             expect (element.getMessage()[0].getType() == OSCTypes::float32);
-            expectEquals (element.getMessage()[0].getFloat32(), testFloat);
+            expect (element.getMessage()[0].getFloat32() == testFloat);
         }
     }
 };

--- a/modules/juce_osc/osc/juce_OSCMessage.cpp
+++ b/modules/juce_osc/osc/juce_OSCMessage.cpp
@@ -89,7 +89,9 @@ void OSCMessage::clear()
 
 //==============================================================================
 void OSCMessage::addInt32 (int32 value)             { arguments.add (OSCArgument (value)); }
+void OSCMessage::addInt64 (int64 value)				{ arguments.add (OSCArgument(value)); }
 void OSCMessage::addFloat32 (float value)           { arguments.add (OSCArgument (value)); }
+void OSCMessage::addFloat64 (double value)			{ arguments.add (OSCArgument(value)); }
 void OSCMessage::addString (const String& value)    { arguments.add (OSCArgument (value)); }
 void OSCMessage::addBlob (MemoryBlock blob)         { arguments.add (OSCArgument (std::move (blob))); }
 void OSCMessage::addColour (OSCColour colour)       { arguments.add (OSCArgument (colour)); }

--- a/modules/juce_osc/osc/juce_OSCMessage.h
+++ b/modules/juce_osc/osc/juce_OSCMessage.h
@@ -124,10 +124,20 @@ public:
     */
     void addInt32 (int32 value);
 
+	/** Creates a new OSCArgument of type int64 with the given value,
+		and adds it to the OSCMessage object.
+	*/
+	void addInt64(int64 value);
+
     /** Creates a new OSCArgument of type float32 with the given value,
         and adds it to the OSCMessage object.
     */
     void addFloat32 (float value);
+
+	/** Creates a new OSCArgument of type float64 with the given value,
+	and adds it to the OSCMessage object.
+*/
+	void addFloat64(double value);
 
     /** Creates a new OSCArgument of type string with the given value,
         and adds it to the OSCMessage object.

--- a/modules/juce_osc/osc/juce_OSCReceiver.cpp
+++ b/modules/juce_osc/osc/juce_OSCReceiver.cpp
@@ -77,6 +77,12 @@ namespace
             return input.readIntBigEndian();
         }
 
+		int64 readInt64()
+		{
+			checkBytesAvailable(8, "OSC input stream exhausted while reading int32");
+			return input.readInt64BigEndian();
+		}
+
         uint64 readUint64()
         {
             checkBytesAvailable (8, "OSC input stream exhausted while reading uint64");
@@ -88,6 +94,12 @@ namespace
             checkBytesAvailable (4, "OSC input stream exhausted while reading float");
             return input.readFloatBigEndian();
         }
+
+		double readFloat64()
+		{
+			checkBytesAvailable(8, "OSC input stream exhausted while reading double");
+			return input.readDoubleBigEndian();
+		}
 
         String readString()
         {
@@ -180,7 +192,9 @@ namespace
             switch (type)
             {
                 case OSCTypes::int32:       return OSCArgument (readInt32());
+				case OSCTypes::int64:       return OSCArgument (readInt64());
                 case OSCTypes::float32:     return OSCArgument (readFloat32());
+				case OSCTypes::float64:     return OSCArgument (readFloat64());
                 case OSCTypes::string:      return OSCArgument (readString());
                 case OSCTypes::blob:        return OSCArgument (readBlob());
                 case OSCTypes::colour:      return OSCArgument (readColour());

--- a/modules/juce_osc/osc/juce_OSCTypes.cpp
+++ b/modules/juce_osc/osc/juce_OSCTypes.cpp
@@ -27,7 +27,9 @@ namespace juce
 {
 
 const OSCType OSCTypes::int32   = 'i';
+const OSCType OSCTypes::int64	= 'h';
 const OSCType OSCTypes::float32 = 'f';
+const OSCType OSCTypes::float64 = 'd';
 const OSCType OSCTypes::string  = 's';
 const OSCType OSCTypes::blob    = 'b';
 const OSCType OSCTypes::colour  = 'r';

--- a/modules/juce_osc/osc/juce_OSCTypes.h
+++ b/modules/juce_osc/osc/juce_OSCTypes.h
@@ -47,7 +47,9 @@ class JUCE_API  OSCTypes
 {
 public:
     static const OSCType int32;
+	static const OSCType int64;
     static const OSCType float32;
+	static const OSCType float64;
     static const OSCType string;
     static const OSCType blob;
     static const OSCType colour;
@@ -55,7 +57,9 @@ public:
     static bool isSupportedType (OSCType type) noexcept
     {
         return type == OSCTypes::int32
+			|| type == OSCTypes::int64
             || type == OSCTypes::float32
+			|| type == OSCTypes::float64
             || type == OSCTypes::string
             || type == OSCTypes::blob
             || type == OSCTypes::colour;


### PR DESCRIPTION
As discussed here:

https://forum.juce.com/t/osctypes-aditional-arguments/57530

for Châtaigne